### PR TITLE
Remove dumps

### DIFF
--- a/aws/action-status.py
+++ b/aws/action-status.py
@@ -92,7 +92,7 @@ def lambda_handler(event, context):
             details = None
     else:
         status = "SUCCEEDED"
-        details = json.dumps(task_results)
+        details = task_results
         display_status = "Function Results Received"
         print("Success -> ", details)
 


### PR DESCRIPTION
Removes an extra json.dumps statement on the result. This was restricting the output from the AP from being used as input to subsequent steps.