### PR TITLE
Reverting to a list of results

### DIFF
--- a/aws/action-status.py
+++ b/aws/action-status.py
@@ -96,8 +96,10 @@ def lambda_handler(event, context):
         display_status = "Function Results Received"
         print("Success -> ", details)
 
-        # details = [str(action_record['tasks'][tt]['result']) for tt in
-        #           action_record['tasks'].keys()]
+        details = [action_record['tasks'][tt]['result'] for tt in
+                  action_record['tasks'].keys()]
+
+        print("List results ->", details)
 
     result = {
         "action_id": action_id,


### PR DESCRIPTION
The results were previously returned as a dict keyed by the task uuid. While this gives us a mapping from task to result, it isn't actually useful in automate because the flow never knows the task uuid and can't map it to a result anyway. Instead, the task uuid makes things more complicated as the flow can't determine where in the dict the result is. It would be better if the results were returned as a list of results. 