### PR TITLE
Add second running_tasks check after polling task status

### DIFF
--- a/aws/action-status.py
+++ b/aws/action-status.py
@@ -92,7 +92,13 @@ def lambda_handler(event, context):
         else:
             status = "ACTIVE"
             details = None
-    else:
+
+    # Now check again to see if everything is done
+    running_tasks = list(filter(lambda task_id: bool(task_id),
+                                [key if not task_results[key][
+                                    'result'] else None
+                                 for key in task_results.keys()]))
+    if running_tasks:
         status = "SUCCEEDED"
         details = task_results
         display_status = "Function Results Received"


### PR DESCRIPTION
The previous version would only return a completed status if no tasks were "running" in the database. If any were running it'd check their status, update results, then return an ACTIVE status. This PR changes the behaviour to re-check for any running tasks after it has polled the tasks' status, meaning it will return a SUCCEEDED status if everything finished.