### PR TITLE
Bump versions to 0.3.4 and include funcx-endpoint

### DIFF
--- a/aws/requirements.txt
+++ b/aws/requirements.txt
@@ -1,3 +1,4 @@
 globus-sdk>=1.7.0
-funcx==0.2.3
+funcx==0.3.4
+funcx-endpoint==0.3.4
 globus_automate_client


### PR DESCRIPTION
We have a flow failing with "funcx-endpoint not installed". I suspect this is coming from the AP not being able to deserialize the payload size exception. At the same time I noticed we were pinned to 0.2.3. This bumps it to 0.3.4.