### PR TITLE
Remove additional cache

### DIFF
--- a/aws/action-status.py
+++ b/aws/action-status.py
@@ -72,6 +72,14 @@ def lambda_handler(event, context):
             if result:
                 task_results[task]['result'] = result
 
+    # Now check again to see if everything is done
+    running_tasks = list(filter(lambda task_id: bool(task_id),
+                                [key if not task_results[key][
+                                    'result'] else None
+                                 for key in task_results.keys()]))
+
+    # Update the Tables entry if there are still running tasks
+    if running_tasks:
         update_response = table.update_item(
             Key={
                 'action-id': action_id
@@ -93,12 +101,8 @@ def lambda_handler(event, context):
             status = "ACTIVE"
             details = None
 
-    # Now check again to see if everything is done
-    running_tasks = list(filter(lambda task_id: bool(task_id),
-                                [key if not task_results[key][
-                                    'result'] else None
-                                 for key in task_results.keys()]))
-    if not running_tasks:
+    # Return SUCCEEDED if there are no tasks still running
+    else:
         status = "SUCCEEDED"
         details = task_results
         display_status = "Function Results Received"

--- a/aws/action-status.py
+++ b/aws/action-status.py
@@ -118,7 +118,7 @@ def lambda_handler(event, context):
     result = {
         "action_id": action_id,
         'status': status,
-        'display_status': 'Function Results Received',
+        'display_status': display_status,
         'details': details
     }
 

--- a/aws/action-status.py
+++ b/aws/action-status.py
@@ -99,6 +99,7 @@ def lambda_handler(event, context):
             display_status = failure
         else:
             status = "ACTIVE"
+            display_status = "Function Still Active"
             details = None
 
     # Return SUCCEEDED if there are no tasks still running


### PR DESCRIPTION
Removes the unnecessary caching of results if all of the results have already been returned. This checks to see if there are any more running tasks and if not, simply returns the result. Previously we would store the result in Tables then check if there were any still running, adding unnecessary overhead to the status request.