### PR TITLE
Don't publish to aws on PRs

### DIFF
--- a/.github/workflows/deploy_lambdas.yml
+++ b/.github/workflows/deploy_lambdas.yml
@@ -6,9 +6,6 @@ on:
   #when there is a push to the main
   push:
     branches: [ serverless ]
-  #when there is a pull to the main
-  pull_request:
-    branches: [ serverless ]
 
 jobs:
   build:


### PR DESCRIPTION
Remove the CI trigger on PRs - this is usually in place for testing, but we don't have any!