### PR TITLE
Fix none result

### DIFF
--- a/aws/action-status.py
+++ b/aws/action-status.py
@@ -60,17 +60,13 @@ def lambda_handler(event, context):
             try:
                 result = fxc.get_result(task)
                 print("---->", result, type(result))
-
             except TaskPending as eek:
                 print("Faiulure ", eek)
-                result = None
             except Exception as eek2:
                 print("Detected an exception: ", eek2)
                 failure = str(eek2)
-                result = None
 
-            if result:
-                task_results[task]['result'] = result
+            task_results[task]['result'] = result
 
         update_response = table.update_item(
             Key={

--- a/aws/funcx-run.py
+++ b/aws/funcx-run.py
@@ -42,7 +42,7 @@ def lambda_handler(event, context):
         'manage_by': manage_by,
         'start_time': now_isoformat(),
     }
-    tasks = {}
+
     batch = fxc.create_batch()
 
     for task in body['body']['tasks']:

--- a/aws/funcx-run.py
+++ b/aws/funcx-run.py
@@ -59,7 +59,7 @@ def lambda_handler(event, context):
     response = table.put_item(
         Item={
             'action-id': action_id,
-            'tasks': json.dumps({task_id: {"result": None} for task_id in batch_res})
+            'tasks': json.dumps({task_id: {"result": None, "completed": False} for task_id in batch_res})
         }
     )
     print("Dynamo", response)


### PR DESCRIPTION
This allows functions to return None (or anything that evaluates to False) by switching the determination of whether a task has completed or not. It adds a `completed` field to the task representation stored in dynamo, rather than evaluating the result.