### PR TITLE
[DO NOT MERGE] Sets the task group id to the user id

### DIFF
--- a/aws/action-status.py
+++ b/aws/action-status.py
@@ -31,9 +31,11 @@ def lambda_handler(event, context):
     openid_auth = AccessTokenAuthorizer(
         event['requestContext']['authorizer']['openid_token'])
 
+    user_id = event['requestContext']['authorizer']['user_id']
+
     FuncXClient.TOKEN_DIR = '/tmp'
     fxc = FuncXClient(fx_authorizer=auth, search_authorizer=search_auth,
-                      openid_authorizer=openid_auth,
+                      openid_authorizer=openid_auth, task_group_id=user_id,
                       use_offprocess_checker=False)
 
     action_id = event['pathParameters']['action-id']

--- a/aws/funcx-run.py
+++ b/aws/funcx-run.py
@@ -19,9 +19,11 @@ def lambda_handler(event, context):
     openid_auth = AccessTokenAuthorizer(
         event['requestContext']['authorizer']['openid_token'])
 
+    user_id = event['requestContext']['authorizer']['user_id']
+
     FuncXClient.TOKEN_DIR = '/tmp'
     fxc = FuncXClient(fx_authorizer=auth, search_authorizer=search_auth,
-                      openid_authorizer=openid_auth,
+                      openid_authorizer=openid_auth, task_group_id=user_id,
                       use_offprocess_checker=False)
 
     dynamodb = boto3.resource('dynamodb')

--- a/aws/requirements.txt
+++ b/aws/requirements.txt
@@ -1,4 +1,4 @@
 globus-sdk>=1.7.0
-funcx==0.3.4
-funcx-endpoint==0.3.4
+funcx==0.3.9
+funcx-endpoint==0.3.9
 globus_automate_client


### PR DESCRIPTION
This will fix the issue of runaway task group ids when the AP is under heavy load. However, it requires a newer version of the funcx SDK be uploaded to Lambda in order to support specifying the task group id.