### PR TITLE
Add ttl to tasks

### DIFF
--- a/aws/action-status.py
+++ b/aws/action-status.py
@@ -1,6 +1,7 @@
 import json
 import boto3
 import decimal
+import datetime
 import traceback
 
 from boto3.dynamodb.conditions import Key
@@ -82,9 +83,10 @@ def lambda_handler(event, context):
             Key={
                 'action-id': action_id
             },
-            UpdateExpression="set tasks=:t",
+            UpdateExpression="set tasks=:t, ttl=:l",
             ExpressionAttributeValues={
-                ':t': json.dumps(task_results, cls=DecimalEncoder)
+                ':t': json.dumps(task_results, cls=DecimalEncoder),
+                ':l': int(datetime.datetime.now().timestamp()) + 1209600 
             },
             ReturnValues="UPDATED_NEW"
         )

--- a/aws/funcx-run.py
+++ b/aws/funcx-run.py
@@ -72,12 +72,15 @@ def lambda_handler(event, context):
 
     # Create a dynamo record where the primary key is this action's ID
     # Tasks is a dict by task_id and contains the eventual results from their
-    # execution. Where there are no more None results then the action is complete
+    # execution. Where there are no more None results then the action is complete.
+    # Set a TTL for two weeks from now.
+    
     if batch_res:
         response = table.put_item(
             Item={
                 'action-id': action_id,
-                'tasks': json.dumps({task_id: {"result": None, "completed": False} for task_id in batch_res})
+                'tasks': json.dumps({task_id: {"result": None, "completed": False} for task_id in batch_res}),
+                'ttl': int(datetime.datetime.now().timestamp()) + 1209600 
             }
         )
         print("Dynamo", response)


### PR DESCRIPTION
For dynamo to automatically remove tasks we need to set the appropriate ttl to the records. This change adds the ttl field to tasks and updates it when the status is updated.