### PR TITLE
Bump endpoint version to 1.0.1

### DIFF
--- a/aws/requirements.txt
+++ b/aws/requirements.txt
@@ -1,4 +1,4 @@
 globus-sdk>=3.0.0
 funcx>=1.0.0
-funcx-endpoint>=1.0.0
+funcx-endpoint>=1.0.1
 globus_automate_client


### PR DESCRIPTION
Increment the funcx-endpoint required version to 1.0.1 to fix an auth token storage issue.