### PR TITLE
Correct bug with undefined details

### DIFF
--- a/aws/action-status.py
+++ b/aws/action-status.py
@@ -85,6 +85,7 @@ def lambda_handler(event, context):
 
     status = "SUCCEEDED"
     display_status = "Function Results Received"
+    details = None
 
     failure = None
     if running_tasks:
@@ -126,7 +127,7 @@ def lambda_handler(event, context):
         if not completed:
             status = "ACTIVE"
             display_status = "Function Active"
-            details = None
+            
 
     # Now check again to see if everything is done
     running_tasks = list(filter(lambda task_id: bool(task_id),


### PR DESCRIPTION
There's a bug where details has not been set when there are still running tasks in a batch. This moves the definition of the details arg and gives it a default value.

Addresses [sc-19796]